### PR TITLE
Corrected bug on Options parse

### DIFF
--- a/src/PhpCoap/CoapPdu.php
+++ b/src/PhpCoap/CoapPdu.php
@@ -253,9 +253,7 @@ class CoapPdu
 		{
 			$optLen = 13 + $buf[$i];
 			$i++;
-		}
-
-		if ( $optLen == 14 )
+		} else if ( $optLen == 14 )
 		{
 			$optLen = 269 + ( $buf[$i] << 8 ) + $buf[ $i + 1 ];
 			$i++;


### PR DESCRIPTION
if $optLen == 13  and $buf[$i] == 1 then the code enter in the next if believing that $optLen is 14 (16-bit format). As result this function enter in infinite loop.